### PR TITLE
Escape database names in mysql commands

### DIFF
--- a/shrink
+++ b/shrink
@@ -49,7 +49,7 @@ for DB in $DBS; do
     if [ -f $DB.sql.gz ]; then
       echo "Database $DB backed up successfully."
       echo "Dropping $DB database..."
-      $MYSQL -u$MYSQL_USER -p$MYSQL_PASS -e "drop database $DB"
+      $MYSQL -u$MYSQL_USER -p$MYSQL_PASS -e "drop database \`$DB\`"
     else
       echo "Backup of database $DB failed."
       exit 1
@@ -65,7 +65,7 @@ if ! test $1; then
       if [ -f $DB.sql.gz ]; then
         echo "Restoring database $DB..."
         gunzip $DB.sql.gz
-        $MYSQL -u$MYSQL_USER -p$MYSQL_PASS -e "create database if not exists $DB"
+        $MYSQL -u$MYSQL_USER -p$MYSQL_PASS -e "create database if not exists \`$DB\`"
         $MYSQL -u$MYSQL_USER -p$MYSQL_PASS $DB < $DB.sql
         if [ $? == 0 ]; then
           echo "Database $DB restored successfully."


### PR DESCRIPTION
Database names that don't conform to a normal standard (ex: ones that have a "-" in them)
will fail to drop and potentially cause issues. This PR uses MySQL quoting to make sure that
they will be dropped appropriately.